### PR TITLE
Fixed automatic creation of output folder

### DIFF
--- a/malware-daily.py
+++ b/malware-daily.py
@@ -120,7 +120,7 @@ def main():
         sys.exit(0)
     if pull_samples:
         if not os.path.exists(pull_samples):
-            os.makedir(pull_samples)
+            os.mkdir(pull_samples)
         pull_samples = os.path.join(pull_samples, '')
         out_file = pull_mb_samples(pull_samples)
         if out_file:


### PR DESCRIPTION
This merge fixes the automatic creation of the user-provided output folder by using the correct `os.mkdir()` function, instead of the `os.makedir()`. 